### PR TITLE
Allow for file system not being writable (i.e. aws lambda)

### DIFF
--- a/test_tscribe.py
+++ b/test_tscribe.py
@@ -56,7 +56,7 @@ def test_multiple_speakers_with_save_as_with_tmp_dir():
 
     # GIVEN a sample file containing multiple speakers, and an output filename, and a writable tmp directory
     # WHEN calling tscribe.write(...)
-    # THEN produce the .docx, named correctly, without errors
+    # THEN produce the .docx, with a chart, named correctly, without errors
 
     """
 
@@ -68,6 +68,7 @@ def test_multiple_speakers_with_save_as_with_tmp_dir():
 
     # Function
     tscribe.write(input_file, save_as=output_file, tmp_dir=tmp_dir)
+    assert os.access(tmp_dir+"chart.png", os.F_OK), "Chart file not found"
     assert os.access(output_file, os.F_OK), "Output file not found"
 
     # Teardown
@@ -129,7 +130,7 @@ def test_single_speaker_with_save_as_with_tmp_dir():
 
     # GIVEN a sample file containing single speaker, and an output filename, and a writable tmp directory
     # WHEN calling tscribe.write(...)
-    # THEN produce the .docx, named correctly, without errors
+    # THEN produce the .docx, with a chart, named correctly, without errors
 
     """
 
@@ -141,6 +142,7 @@ def test_single_speaker_with_save_as_with_tmp_dir():
 
     # Function
     tscribe.write(input_file, save_as=output_file, tmp_dir=tmp_dir)
+    assert os.access(tmp_dir+"chart.png", os.F_OK), "Chart file not found"
     assert os.access(output_file, os.F_OK), "Output file not found"
 
     # Teardown

--- a/test_tscribe.py
+++ b/test_tscribe.py
@@ -121,3 +121,28 @@ def test_single_speaker_with_save_as():
     # Teardown
     os.remove(output_file)
     os.remove("chart.png")
+
+
+def test_single_speaker_with_save_as_with_tmp_dir():
+    """
+    Test output exists with single speaker input, and save_as defined, and tmp_dir defined
+
+    # GIVEN a sample file containing single speaker, and an output filename, and a writable tmp directory
+    # WHEN calling tscribe.write(...)
+    # THEN produce the .docx, named correctly, without errors
+
+    """
+
+    # Setup
+    input_file = "sample_single.json"
+    output_file = "test_sample.docx"
+    tmp_dir = "/tmp/"
+    assert os.access(input_file, os.F_OK), "Input file not found"
+
+    # Function
+    tscribe.write(input_file, save_as=output_file, tmp_dir=tmp_dir)
+    assert os.access(output_file, os.F_OK), "Output file not found"
+
+    # Teardown
+    os.remove(output_file)
+    os.remove(tmp_dir+"chart.png")

--- a/test_tscribe.py
+++ b/test_tscribe.py
@@ -54,7 +54,7 @@ def test_single_speaker():
     """
     Test output exists with single speaker input
 
-    # GIVEN a sample file containing multiple speakers
+    # GIVEN a sample file containing single speaker
     # WHEN calling tscribe.write(...)
     # THEN produce the .docx without errors
 
@@ -78,7 +78,7 @@ def test_single_speaker_with_save_as():
     """
     Test output exists with single speaker input, and save_as defined
 
-    # GIVEN a sample file containing multiple speakers, and an output filename
+    # GIVEN a sample file containing single speaker, and an output filename
     # WHEN calling tscribe.write(...)
     # THEN produce the .docx, named correctly, without errors
 

--- a/test_tscribe.py
+++ b/test_tscribe.py
@@ -50,6 +50,31 @@ def test_multiple_speakers_with_save_as():
     os.remove("chart.png")
 
 
+def test_multiple_speakers_with_save_as_with_tmp_dir():
+    """
+    Test output exists with multiple speaker input, and save_as defined, and tmp_dir defined
+
+    # GIVEN a sample file containing multiple speakers, and an output filename, and a writable tmp directory
+    # WHEN calling tscribe.write(...)
+    # THEN produce the .docx, named correctly, without errors
+
+    """
+
+    # Setup
+    input_file = "sample_multiple.json"
+    output_file = "test_sample.docx"
+    tmp_dir = "/tmp/"
+    assert os.access(input_file, os.F_OK), "Input file not found"
+
+    # Function
+    tscribe.write(input_file, save_as=output_file, tmp_dir=tmp_dir)
+    assert os.access(output_file, os.F_OK), "Output file not found"
+
+    # Teardown
+    os.remove(output_file)
+    os.remove(tmp_dir+"chart.png")
+
+
 def test_single_speaker():
     """
     Test output exists with single speaker input

--- a/tscribe/__init__.py
+++ b/tscribe/__init__.py
@@ -131,8 +131,14 @@ def write(file, **kwargs):
     plt.yticks(range(0, 101, 10))
     plt.title('Accuracy during video')
     plt.legend(['Accuracy average (mean)', 'Individual words'], loc='lower center')
-    plt.savefig('chart.png')
-    document.add_picture('chart.png', width=Cm(14.64))
+
+    # not all file systems are writable, so we allow specifying a writable tmp directory
+    # alternatively if it is not set, we use ./
+    tmp_dir = kwargs.get('tmp_dir', "./")
+    chart_file_name = tmp_dir+'chart.png'
+
+    plt.savefig(chart_file_name)
+    document.add_picture(chart_file_name, width=Cm(14.64))
     document.paragraphs[-1].alignment = WD_ALIGN_PARAGRAPH.CENTER
     document.add_page_break()
 


### PR DESCRIPTION
I've been hoping to use this fantastic repo to allow transcriptions to docx simply by uploading an mp4 to S3. This required the use of aws lambda to run tscribe on the json output.

AWS lambda however is only writable within /tmp/ and so the chart.png that is created caused an error.

I've added an optional argument to specify where chart.png is written to. Hopefully this is compatible with your plans for the project.

Thanks for writing such a great tool.